### PR TITLE
1.x

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 Joan Fabrégat / Code Inc. SAS
+Copyright (c) 2017 - 2018 Joan Fabrégat / Code Inc. SAS
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/assets/HtmlErrorRenderer/styles.css
+++ b/assets/HtmlErrorRenderer/styles.css
@@ -16,7 +16,7 @@
  * Author:   Joan Fabrégat <joan@codeinc.fr>
  * Date:     19/02/2018
  * Time:     14:14
- * Project:  lib-errordisplay
+ * Project:  ErrorRenderer
  */
 
 div.exception-report {

--- a/assets/HtmlErrorRenderer/styles.css
+++ b/assets/HtmlErrorRenderer/styles.css
@@ -2,7 +2,7 @@
  * +---------------------------------------------------------------------+
  * | CODE INC. SOURCE CODE                                               |
  * +---------------------------------------------------------------------+
- * | Copyright (c) 2017 - Code Inc. SAS - All Rights Reserved.           |
+ * | Copyright (c) 2017 - 2018 - Code Inc. SAS - All Rights Reserved.    |
  * | Visit https://www.codeinc.fr for more information about licensing.  |
  * +---------------------------------------------------------------------+
  * | NOTICE:  All information contained herein is, and remains the       |
@@ -67,13 +67,30 @@ div.exception-report .exception-location {
 	opacity: .7;
 	/*font-style: italic;*/
 }
-div.exception-report div.exception > ol.exception-trace {
+div.exception-report div.exception > div.exception-trace strong {
+	cursor: pointer;
+}
+div.exception-report div.exception > div.exception-trace strong:before {
+	content: '▶';
+	display: inline-block;
+	transform: rotate(90deg);
+	transition: transform 300ms ease;
+	font-size: 10px;
+	margin-right: 7px;
+}
+div.exception-report div.exception > div.exception-trace.closed strong:before {
+	transform: rotate(0);
+}
+div.exception-report div.exception > div.exception-trace {
 	margin-top: 20px;
 }
-div.exception-report div.exception > ol.exception-trace li:not(:last-of-type) {
+div.exception-report div.exception > div.exception-trace.closed ol {
+	display: none;
+}
+div.exception-report div.exception > div.exception-trace ol li:not(:last-of-type) {
 	margin-bottom: 10px;
 }
-div.exception-report div.exception > ol.exception-trace li span.exception-trace-arg {
+div.exception-report div.exception > div.exception-trace ol li span.exception-trace-arg {
 	display: inline-block;
 	margin: 2px 0 2px 20px;
 }

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "codeinc/error-renderer",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "description": "Code Inc.'s error display library",
   "homepage": "https://github.com/CodeIncHQ/ErrorRenderer",
   "type": "library",

--- a/src/AbstractErrorRenderer.php
+++ b/src/AbstractErrorRenderer.php
@@ -17,7 +17,7 @@
 // Author:   Joan Fabrégat <joan@codeinc.fr>
 // Date:     15/12/2017
 // Time:     13:07
-// Project:  lib-errordisplay
+// Project:  ErrorRenderer
 //
 namespace CodeInc\ErrorRenderer;
 use Throwable;

--- a/src/ConsoleErrorRenderer.php
+++ b/src/ConsoleErrorRenderer.php
@@ -17,7 +17,7 @@
 // Author:   Joan Fabrégat <joan@codeinc.fr>
 // Date:     15/12/2017
 // Time:     11:44
-// Project:  lib-errordisplay
+// Project:  ErrorRenderer
 //
 namespace CodeInc\ErrorRenderer;
 use Colors\Color;

--- a/src/ErrorRendererException.php
+++ b/src/ErrorRendererException.php
@@ -17,7 +17,7 @@
 // Author:   Joan Fabrégat <joan@codeinc.fr>
 // Date:     15/12/2017
 // Time:     13:12
-// Project:  lib-errordisplay
+// Project:  ErrorRenderer
 //
 namespace CodeInc\ErrorRenderer;
 use Throwable;

--- a/src/ErrorRendererInterface.php
+++ b/src/ErrorRendererInterface.php
@@ -17,7 +17,7 @@
 // Author:   Joan Fabrégat <joan@codeinc.fr>
 // Date:     15/12/2017
 // Time:     11:48
-// Project:  lib-errordisplay
+// Project:  ErrorRenderer
 //
 namespace CodeInc\ErrorRenderer;
 use Throwable;

--- a/src/HtmlErrorRenderer.php
+++ b/src/HtmlErrorRenderer.php
@@ -17,7 +17,7 @@
 // Author:   Joan Fabrégat <joan@codeinc.fr>
 // Date:     06/12/2017
 // Time:     18:54
-// Project:  lib-errordisplay
+// Project:  ErrorRenderer
 //
 namespace CodeInc\ErrorRenderer;
 use Throwable;

--- a/src/HtmlErrorRenderer.php
+++ b/src/HtmlErrorRenderer.php
@@ -3,7 +3,7 @@
 // +---------------------------------------------------------------------+
 // | CODE INC. SOURCE CODE                                               |
 // +---------------------------------------------------------------------+
-// | Copyright (c) 2017 - Code Inc. SAS - All Rights Reserved.           |
+// | Copyright (c) 2017 - 2018 - Code Inc. SAS - All Rights Reserved.    |
 // | Visit https://www.codeinc.fr for more information about licensing.  |
 // +---------------------------------------------------------------------+
 // | NOTICE:  All information contained herein is, and remains the       |
@@ -30,157 +30,160 @@ use Throwable;
  * @author Joan Fabrégat <joan@codeinc.fr>
  */
 class HtmlErrorRenderer extends AbstractErrorRenderer {
-	// Options
-	public const OPT_RENDER_FUNC_ARGS = 1024;
-	public const OPT_RENDER_CSS = 2048;
-	public const OPT_ALL = parent::OPT_ALL | self::OPT_RENDER_FUNC_ARGS | self::OPT_RENDER_CSS;
-	public const OPT_DEFAULT = parent::OPT_DEFAULT | self::OPT_RENDER_CSS;
+    // Options
+    public const OPT_RENDER_FUNC_ARGS = 1024;
+    public const OPT_RENDER_CSS = 2048;
+    public const OPT_ALL = parent::OPT_ALL | self::OPT_RENDER_FUNC_ARGS | self::OPT_RENDER_CSS;
+    public const OPT_DEFAULT = parent::OPT_DEFAULT | self::OPT_RENDER_CSS;
 
-	/**
-	 * BrowserRenderingEngine constructor.
-	 *
-	 * @param Throwable $throwable
-	 * @param int|null $options
-	 */
-	public function __construct(Throwable $throwable, int $options = null) {
-		parent::__construct($throwable, $options !== null ? $options : self::OPT_DEFAULT);
-	}
+    /**
+     * BrowserRenderingEngine constructor.
+     *
+     * @param Throwable $throwable
+     * @param int|null $options
+     */
+    public function __construct(Throwable $throwable, int $options = null) {
+        parent::__construct($throwable, $options !== null ? $options : self::OPT_DEFAULT);
+    }
 
-	/**
-	 * Returns the HTML code.
-	 *
-	 * @return string
-	 */
-	public function get():string {
-		ob_start();
-		?>
-		<!-- --------------------------------- EXCEPTION --------------------------------- -->
-		<div class="exception-report" data-type="<?=htmlspecialchars(get_class($this->throwable))?>">
-			<?
-			$this->renderTitle("Error", 4);
-			// Renders the main exception
-			$this->renderException($this->throwable);
+    /**
+     * Returns the HTML code.
+     *
+     * @return string
+     */
+    public function get():string {
+        ob_start();
+        ?>
+        <!-- --------------------------------- EXCEPTION --------------------------------- -->
+        <div class="exception-report" data-type="<?=htmlspecialchars(get_class($this->throwable))?>">
+            <?
+            $this->renderTitle("Error", 4);
+            // Renders the main exception
+            $this->renderException($this->throwable);
 
-			// Renders the previous exceptions
-			if ($this->options & self::OPT_RENDER_BACKTRACE && $previous = $this->throwable->getPrevious()) {
-				echo '<div class="exception-previous">';
-				$this->renderTitle("Previous exceptions", 2);
-				do {
-					$this->renderException($previous);
-				}
-				while ($previous = $previous->getPrevious());
-				echo '</div>';
-			}
-			$this->renderTitle("End error", 4);
+            // Renders the previous exceptions
+            if ($this->options & self::OPT_RENDER_BACKTRACE && $previous = $this->throwable->getPrevious()) {
+                echo '<div class="exception-previous">';
+                $this->renderTitle("Previous exceptions", 2);
+                do {
+                    $this->renderException($previous);
+                }
+                while ($previous = $previous->getPrevious());
+                echo '</div>';
+            }
+            $this->renderTitle("End error", 4);
 
-			// Renders the CSS
-			$this->renderStyles();
-			?>
-		</div>
-		<!-- --------------------------------- END EXCEPTION --------------------------------- -->
-		<?
-		return ob_get_clean();
-	}
+            // Renders the CSS
+            $this->renderStyles();
+            ?>
+        </div>
+        <!-- --------------------------------- END EXCEPTION --------------------------------- -->
+        <?
+        return ob_get_clean();
+    }
 
-	/**
-	 * Renders a title.
-	 *
-	 * @param string $title
-	 * @param int|null $sideSize
-	 */
-	private function renderTitle(string $title, int $sideSize = null):void {
-		$titleSide = $sideSize ? str_pad("", $sideSize, "-") : null;
-		echo '<div class="exception-title">'
-			.($titleSide ? "$titleSide " : "")
-			.htmlspecialchars($title)
-			.($titleSide ? " $titleSide" : "")
-			.'</div>';
-	}
+    /**
+     * Renders a title.
+     *
+     * @param string $title
+     * @param int|null $sideSize
+     */
+    private function renderTitle(string $title, int $sideSize = null):void {
+        $titleSide = $sideSize ? str_pad("", $sideSize, "-") : null;
+        echo '<div class="exception-title">'
+            .($titleSide ? "$titleSide " : "")
+            .htmlspecialchars($title)
+            .($titleSide ? " $titleSide" : "")
+            .'</div>';
+    }
 
-	/**
-	 * Renders and exception.
-	 *
-	 * @param \Throwable $exception
-	 */
-	private function renderException(\Throwable $exception):void {
-		$exceptionClass = get_class($exception);
-		?>
-		<div class="exception" data-type="<?=htmlspecialchars($exceptionClass)?>">
-			<span class="exception-class">[<?=htmlspecialchars($exceptionClass)?>]</span>
-			<span class="exception-message">
+    /**
+     * Renders and exception.
+     *
+     * @param \Throwable $exception
+     */
+    private function renderException(\Throwable $exception):void {
+        $exceptionClass = get_class($exception);
+        ?>
+        <div class="exception" data-type="<?=htmlspecialchars($exceptionClass)?>">
+            <span class="exception-class">[<?=htmlspecialchars($exceptionClass)?>]</span>
+            <span class="exception-message">
 				<?=htmlspecialchars($exception->getMessage())?>
 			</span><br>
-			<span class="exception-location">
+            <span class="exception-location">
 				<?=htmlspecialchars($exception->getFile()).':'.$exception->getLine()?>
 			</span>
-			<? $this->renderExceptionTrace($exception) ?>
-		</div>
-		<?
-	}
+            <? $this->renderExceptionTrace($exception) ?>
+        </div>
+        <?
+    }
 
-	/**
-	 * Renders the Exception backtrace
-	 *
-	 * @param \Throwable $exception
-	 */
-	private function renderExceptionTrace(\Throwable $exception):void {
-		if ($this->options & self::OPT_RENDER_BACKTRACE) {
-			?>
-			<ol class="exception-trace">
-				<? foreach ($exception->getTrace() as $item) {
-					echo "<li>";
-					if (isset($item["function"]) && $item["function"]) {
-						echo "<span class='exception-trace-function'>\n";
-						if (isset($item["class"], $item["type"]) && $item["class"] && $item["type"]) {
-							echo htmlspecialchars($item["class"].$item["type"]);
-						}
-						echo htmlspecialchars($item["function"]);
-						echo "(";
-						if ($this->options & self::OPT_RENDER_FUNC_ARGS && isset($item["args"])
-							&& is_array($item["args"]) && !empty($item["args"])) {
+    /**
+     * Renders the Exception backtrace
+     *
+     * @param \Throwable $exception
+     */
+    private function renderExceptionTrace(\Throwable $exception):void {
+        if ($this->options & self::OPT_RENDER_BACKTRACE) {
+            ?>
+            <div class="exception-trace closed">
+                <strong onclick="this.parentNode.classList.toggle('closed');">Backtrace</strong>
+                <ol>
+                    <? foreach ($exception->getTrace() as $item) {
+                        echo "<li>";
+                        if (isset($item["function"]) && $item["function"]) {
+                            echo "<span class='exception-trace-function'>\n";
+                            if (isset($item["class"], $item["type"]) && $item["class"] && $item["type"]) {
+                                echo htmlspecialchars($item["class"].$item["type"]);
+                            }
+                            echo htmlspecialchars($item["function"]);
+                            echo "(";
+                            if ($this->options & self::OPT_RENDER_FUNC_ARGS && isset($item["args"])
+                                && is_array($item["args"]) && !empty($item["args"])) {
 
-							$i = 0;
-							echo "<br>";
-							foreach ($item["args"] as $arg) {
-								if (!is_string($arg)) {
-									if (is_object($arg) && method_exists($arg, '__toString')) {
-										$arg = "\"".htmlspecialchars($arg->__toString())."\"";
-									}
-									else {
-										$arg = "<i>".gettype($arg)."</i>";
-									}
-								}
-								else {
-									$arg = "\"".htmlspecialchars($arg)."\"";
-								}
-								echo "<span class='exception-trace-arg'>$arg";
-								if (++$i < count($item["args"])) echo ", ";
-								echo "</span><br>";
-							}
-						}
-						echo ")</span><br>";
-					}
-					if (isset($item['file'])) {
-						echo "<span class='exception-location'>"
-							.htmlspecialchars($item['file']);
-						if (isset($item['line'])) echo ":".$item['line'];
-						echo "</span>\n";
-					}
-					echo "</li>\n";
-				} ?>
-			</ol>
-			<?
-		}
-	}
+                                $i = 0;
+                                echo "<br>";
+                                foreach ($item["args"] as $arg) {
+                                    if (!is_string($arg)) {
+                                        if (is_object($arg) && method_exists($arg, '__toString')) {
+                                            $arg = "\"".htmlspecialchars($arg->__toString())."\"";
+                                        }
+                                        else {
+                                            $arg = "<i>".gettype($arg)."</i>";
+                                        }
+                                    }
+                                    else {
+                                        $arg = "\"".htmlspecialchars($arg)."\"";
+                                    }
+                                    echo "<span class='exception-trace-arg'>$arg";
+                                    if (++$i < count($item["args"])) echo ", ";
+                                    echo "</span><br>";
+                                }
+                            }
+                            echo ")</span><br>";
+                        }
+                        if (isset($item['file'])) {
+                            echo "<span class='exception-location'>"
+                                .htmlspecialchars($item['file']);
+                            if (isset($item['line'])) echo ":".$item['line'];
+                            echo "</span>\n";
+                        }
+                        echo "</li>\n";
+                    } ?>
+                </ol>
+            </div>
+            <?
+        }
+    }
 
-	/**
-	 * Renders the CSS styles.
-	 */
-	private function renderStyles():void {
-		if ($this->options & self::OPT_RENDER_CSS) {
-			echo '<style>';
-			readfile(__DIR__.'/../assets/HtmlErrorRenderer/styles.css');
-			echo '</style>';
-		}
-	}
+    /**
+     * Renders the CSS styles.
+     */
+    private function renderStyles():void {
+        if ($this->options & self::OPT_RENDER_CSS) {
+            echo '<style>';
+            readfile(__DIR__.'/../assets/HtmlErrorRenderer/styles.css');
+            echo '</style>';
+        }
+    }
 }

--- a/tests/TerminalRenderingEngineTest.php
+++ b/tests/TerminalRenderingEngineTest.php
@@ -17,7 +17,7 @@
 // Author:   Joan Fabrégat <joan@codeinc.fr>
 // Date:     19/02/2018
 // Time:     14:32
-// Project:  lib-errordisplay
+// Project:  ErrorRenderer
 //
 namespace Tests\CodeInc\ErrorDisplay;
 use CodeInc\ErrorRenderer\ConsoleErrorRenderer;


### PR DESCRIPTION
The backtrace is now folded by default in HTML:
<img width="1022" alt="capture_d ecran_2018-06-15_a_17_14_01" src="https://user-images.githubusercontent.com/4227907/41475632-9929e0d8-70bf-11e8-8c02-fe7b277e3225.png">
