### PR TITLE
bug fixes

### DIFF
--- a/assets/HtmlErrorRenderer/noscript-styles.css
+++ b/assets/HtmlErrorRenderer/noscript-styles.css
@@ -19,3 +19,6 @@
 div.exception-report div.exception > div.exception-trace.closed ol {
     display: block!important;
 }
+div.exception-report div.exception > div.exception-trace strong {
+    cursor: default!important;
+}

--- a/src/HtmlErrorRenderer.php
+++ b/src/HtmlErrorRenderer.php
@@ -21,7 +21,6 @@
 //
 namespace CodeInc\ErrorRenderer;
 use MatthiasMullie\Minify\CSS;
-use MatthiasMullie\Minify\JS;
 use ReflectionClass;
 use Throwable;
 
@@ -145,7 +144,7 @@ class HtmlErrorRenderer extends AbstractErrorRenderer
      */
     private function renderExceptionTrace(\Throwable $exception):void
     {
-        if ($this->options & self::OPT_RENDER_BACKTRACE) {
+        if ($this->options & self::OPT_RENDER_BACKTRACE && $exception->getTrace()) {
             ?>
             <div class="exception-trace closed">
                 <strong onclick="this.parentNode.classList.toggle('closed');">Backtrace</strong>


### PR DESCRIPTION
* The cursor is now the default cursor on the 'backtrace' title when the trace can not be clause or open because Javascript is not available
* The trace section is now hidden for exception without trace